### PR TITLE
Fix user profile deletion bug

### DIFF
--- a/src/utils/deleteAccount.ts
+++ b/src/utils/deleteAccount.ts
@@ -3,75 +3,90 @@ import { logger } from "@/utils/logger";
 
 /** Supprime le compte (Edge Function) + déconnecte proprement le client */
 export async function deleteAccountAndSignOut(): Promise<boolean> {
+  // Marqueur pour éviter recréation de profil pendant la suppression
+  try {
+    localStorage.setItem('deletion_in_progress', '1');
+  } catch {}
+
   try {
     const { data: sessionData } = await supabase.auth.getSession();
     const accessToken = sessionData?.session?.access_token;
 
-    if (accessToken) {
-      logger.info("[account-deletion] Appel Edge Function delete-account...");
-      const { data, error } = await supabase.functions.invoke("delete-account", {
-        method: "POST",
-        headers: { Authorization: `Bearer ${accessToken}` },
-      });
-      
-      logger.info("[account-deletion] Réponse de la fonction:", { data, error });
-      
-      if (error) {
-        logger.warn("[account-deletion] Function erreur (on continue le nettoyage local):", error);
-      } else if (data?.ok) {
-        logger.info("[account-deletion] Suppression côté serveur réussie");
-      }
-    } else {
-      logger.warn("[account-deletion] Pas d'access token; on nettoie localement.");
+    if (!accessToken) {
+      throw new Error("Session invalide: aucun access token");
     }
-  } catch (e) {
-    logger.warn("[account-deletion] Erreur appel function (on continue local):", e);
-  }
 
-  // Nettoyage client (évite "toujours connecté")
-  try {
+    logger.info("[account-deletion] Appel Edge Function delete-account...");
+    const { data, error } = await supabase.functions.invoke("delete-account", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+
+    logger.info("[account-deletion] Réponse de la fonction:", { data, error });
+
+    if (error) {
+      throw new Error(error.message || "Erreur lors de l'appel de la fonction de suppression");
+    }
+
+    if (!data?.ok) {
+      throw new Error((data as any)?.error || "Suppression serveur non confirmée");
+    }
+
+    logger.info("[account-deletion] Suppression côté serveur réussie");
+  } catch (e: any) {
+    logger.error("[account-deletion] Échec suppression serveur:", e);
+    // On propage l'erreur pour que l'UI affiche un message et n'indique pas un succès trompeur
+    throw e;
+  } finally {
+    // Nettoyage client (évite "toujours connecté")
     try {
-      // @ts-ignore
-      supabase.realtime.removeAllChannels?.();
-      // @ts-ignore
-      supabase.realtime.disconnect?.();
-    } catch {}
-
-    try { 
-      await supabase.auth.signOut({ scope: "local" }); 
-    } catch {}
-    
-    try { 
-      await supabase.auth.signOut({ scope: "global" }); 
-    } catch (e) { 
-      console.warn("signOut global:", e); 
-    }
-
-    try { 
-      localStorage.clear(); 
-      sessionStorage.clear(); 
+      localStorage.setItem('logout_in_progress', '1');
     } catch {}
 
     try {
-      // @ts-ignore
-      if (indexedDB && typeof indexedDB.databases === "function") {
+      try {
         // @ts-ignore
-        const dbs = await indexedDB.databases();
-        for (const db of dbs) { 
-          if (db.name) indexedDB.deleteDatabase(db.name); 
-        }
+        supabase.realtime.removeAllChannels?.();
+        // @ts-ignore
+        supabase.realtime.disconnect?.();
+      } catch {}
+
+      try {
+        await supabase.auth.signOut({ scope: "local" });
+      } catch {}
+      
+      try {
+        await supabase.auth.signOut({ scope: "global" });
+      } catch (e) {
+        console.warn("signOut global:", e);
       }
-    } catch {}
 
-    try {
-      document.cookie.split(";").forEach(c => { 
-        document.cookie = c.replace(/^ +/, "").replace(/=.*/, "=;expires=Thu, 01 Jan 1970 00:00:00 UTC;path=/;");
-      });
-    } catch {}
+      try {
+        localStorage.clear();
+        sessionStorage.clear();
+      } catch {}
 
-    return true;
-  } catch (e) {
-    console.error("[account-deletion] Erreur nettoyage local:", e);
-    return false;
+      try {
+        // @ts-ignore
+        if (indexedDB && typeof indexedDB.databases === "function") {
+          // @ts-ignore
+          const dbs = await indexedDB.databases();
+          for (const db of dbs) {
+            if (db.name) indexedDB.deleteDatabase(db.name);
+          }
+        }
+      } catch {}
+
+      try {
+        document.cookie.split(";").forEach(c => {
+          document.cookie = c.replace(/^ +/, "").replace(/=.*/, "=;expires=Thu, 01 Jan 1970 00:00:00 UTC;path=/;");
+        });
+      } catch {}
+    } finally {
+      try { localStorage.removeItem('deletion_in_progress'); } catch {}
+      try { localStorage.removeItem('logout_in_progress'); } catch {}
+    }
   }
+
+  return true;
 }


### PR DESCRIPTION
Fixes user profile deletion to prevent immediate re-login by ensuring server-side deletion and adding a temporary email blocklist.

Previously, the client-side `deleteAccountAndSignOut` function would clean up locally even if the server-side deletion failed, leaving the Auth user intact. Additionally, the `profiles` table was not correctly deleted due to using `user_id` instead of `id`, and no mechanism prevented immediate re-registration with the same credentials.

---
<a href="https://cursor.com/background-agent?bcId=bc-55b0e2a9-9550-4be4-8e29-839540ae55bd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-55b0e2a9-9550-4be4-8e29-839540ae55bd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

